### PR TITLE
Removing parenthesis causing error compiling

### DIFF
--- a/ESP8266_Simple.cpp
+++ b/ESP8266_Simple.cpp
@@ -462,7 +462,7 @@ byte ESP8266_Simple::serveHttpRequest()
     //memset(cmdBuffer,0,sizeof(cmdBuffer));
     //strncpy_P(cmdBuffer, PSTR("AT+CIPCLOSE="), sizeof(cmdBuffer)-1);
     //itoa(muxChannel, cmdBuffer+strlen(cmdBuffer),10);
-    if((responseCode = this->sendCommand("AT+CIPCLOSE=0\r\n"))) != ESP8266_OK)
+    if((responseCode = this->sendCommand("AT+CIPCLOSE=0\r\n")) != ESP8266_OK)
     {
       return responseCode;
     }      


### PR DESCRIPTION
Fixes this error:
![Error](http://i.imgur.com/7sixE83.png)
